### PR TITLE
Understand-Anything: pre-dev switch, Helm/E2E/Infra dashboards, nightly full rebuild

### DIFF
--- a/tools/understand-anything/README.md
+++ b/tools/understand-anything/README.md
@@ -10,32 +10,67 @@ see ORISO-Docs#61).
 
 | Script | Purpose |
 |---|---|
+| `ua-nightly-full.sh` | **The nightly driver (02:00 cron).** Full deterministic rebuild: advances every repo clone to its origin tip, regenerates all 12 per-repo graphs (generate + enrich), installs them, and rebuilds the super-graph. ~90 s total. Replaces the overlay/baseline approach, which could silently freeze on a stale base. |
 | `ua-generate.mjs` | Per-repo deterministic graph generator. Walks tracked files, runs the understand-anything-plugin core (tree-sitter for code, built-in parsers for yaml/md/sql/sh/…), builds nodes/edges (contains/imports/calls), heuristic layers + tour, fingerprints, meta. ~3s per repo, no LLM. |
-| `ua-enrich-merge.mjs` | Merges a coarse enrichment JSON (concept/flow nodes + related-edges, authored per repo) into a staging graph; adds a "Domain Concepts" layer; validates. |
-| `enrichments/*.json` | The per-repo enrichment content (concepts/flows grounded in READMEs + class inventories), state of 2026-07-16. |
-| `ua-build-supergraph.mjs` | Builds the cross-repo super-graph: prefixes node ids (`<Repo>::<id>`), adds `repo:*` root nodes + containment edges, per-repo layers, an overview tour, and **deterministic cross-repo `depends_on` edges** (service-keyword evidence, count ≥ 2). `--install` deploys into `ORISO-Docs/.understand-anything/`. |
-| `refresh-understand-ultralite-local.sh` | Copy of the server's nightly 02:00 cron (patched 2026-07-16): overlay baseline now comes from the graph's `meta.json.gitCommitHash`, and clones advance to `origin/<branch>` nightly (preserving `.understand-anything/`) so file views stay current and the baseline can never freeze again. |
+| `ua-enrich-merge.mjs` | Merges a coarse enrichment JSON (concept/flow nodes + related-edges, authored per repo) into a staging graph; adds a "Domain Concepts" layer; validates (unresolved refs are reported and must be fixed). |
+| `enrichments/*.json` | The per-repo enrichment content (concepts/flows grounded in READMEs + class inventories). 12 repos covered since 2026-08-05 (added helm, e2e, infra, database). |
+| `ua-build-supergraph.mjs` | Builds the cross-repo super-graph: prefixes node ids (`<Repo>::<id>`), adds `repo:*` root nodes + containment edges, per-repo layers, an overview tour, and **deterministic cross-repo `depends_on` edges** (service-keyword evidence, count ≥ 2). `--install` deploys into `ORISO-Docs/.understand-anything/` and writes a `meta.json` for freshness checks. |
+| `refresh-understand-ultralite-local.sh` | RETIRED 2026-08-05 (kept for reference). The old nightly overlay refresh; superseded by `ua-nightly-full.sh`. |
 
-## Rebuild procedure (per repo, on the server)
+## Indexed repos & branches
+
+Since 2026-08-05 the board tracks the **pre-dev integration branches** where they
+exist, and 15 dashboards run on ports 5173–5185:
+
+| Repo | Branch | Dashboard |
+|---|---|---|
+| ORISO-Frontend, ORISO-Admin, ORISO-UserService, ORISO-AgencyService, ORISO-ConsultingTypeService, ORISO-TenantService | `pre-dev` | per-service |
+| ORISO-Database, ORISO-Kubernetes (legacy, analysis only) | `dev` | per-repo |
+| ORISO-Keycloak | `feature/understand-anything-graph` | per-repo |
+| ORISO-Helm, ORISO-E2E, ORISO-Infra | `main` | per-repo (added 2026-08-05) |
+| ORISO-Docs | `main` | hosts the super-graph (`/docs/`) |
+
+## Nightly operation (server)
+
+```
+0 2 * * *   ua-nightly-full.sh          # full rebuild of everything
+30 2 * * *  prune daily .bak-* > 7 days
+35 2 * * *  prune .bak-prerebuild-* > 30 days
+```
+
+Dashboards read the graph JSON from disk per request — no container restarts
+are needed after a rebuild.
+
+## Manual rebuild (server)
+
+```bash
+/opt/oriso-understand/_rebuild/ua-nightly-full.sh
+```
+
+Or a single repo:
 
 ```bash
 cd /opt/oriso-understand/_rebuild
 node ua-generate.mjs /opt/oriso-understand/<Repo> <Repo> ./<Repo>   # deterministic base
-node ua-enrich-merge.mjs <Repo> enrichments/enrich-<repo>.json      # coarse semantics
-# validate output, then install:
+node ua-enrich-merge.mjs ./<Repo> enrich-<repo>.json                # coarse semantics
 cp ./<Repo>/{knowledge-graph.json,meta.json,fingerprints.json} /opt/oriso-understand/<Repo>/.understand-anything/
-docker compose up -d --force-recreate <service>
 node ua-build-supergraph.mjs --install                              # refresh super-graph
 ```
 
-Live graphs keep `.bak-prerebuild-*` rollback copies next to them. Daily `.bak-*`
-files are pruned after 7 days by a companion cron (02:30).
+Live graphs keep `.bak-prerebuild-*` rollback copies next to them (pruned after
+30 days). Daily `.bak-*` files are pruned after 7 days.
 
 ## Notes
 
 - The plugin core lives at
   `/opt/oriso-understand/understand-anything-plugin/understand-anything-plugin/packages/core/dist/`
   (v2.7.x). All scripts import its public API — no LLM calls anywhere in this pipeline.
+- Server access: key-auth only (`ssh oriso-understand-root`); private repos
+  (E2E, Infra) are fetched via the same credential-store pattern as the pre-dev
+  deploy server.
+- Enrichment `related` refs must point at files the generator parses into nodes
+  (code, yaml, md, sql, sh). Lock files, dotfiles, `.ftl`/`.properties`, `.txt`,
+  and anything under `.github/` do not resolve.
 - ORISO-Kubernetes is archived upstream (Neusta-owned): analysis only, never push.
 - Full context: rebuild EPIC ORISO-Docs#61 and the plan in the workspace
   (`0 - Docs/plans/2026-07-15-understand-anything-semantic-rebuild.md`).

--- a/tools/understand-anything/README.md
+++ b/tools/understand-anything/README.md
@@ -20,7 +20,7 @@ see ORISO-Docs#61).
 ## Indexed repos & branches
 
 Since 2026-08-05 the board tracks the **pre-dev integration branches** where they
-exist, and 15 dashboards run on ports 5173–5185:
+exist, and 13 dashboards run on ports 5173–5185:
 
 | Repo | Branch | Dashboard |
 |---|---|---|
@@ -57,8 +57,10 @@ cp ./<Repo>/{knowledge-graph.json,meta.json,fingerprints.json} /opt/oriso-unders
 node ua-build-supergraph.mjs --install                              # refresh super-graph
 ```
 
-Live graphs keep `.bak-prerebuild-*` rollback copies next to them (pruned after
-30 days). Daily `.bak-*` files are pruned after 7 days.
+The nightly pipeline writes daily `.bak-<timestamp>` copies (pruned after
+7 days). `.bak-prerebuild-*` files are manual rollback snapshots taken before
+risky rebuilds (e.g. the 2026-08-05 pre-dev switch); the 02:35 cron prunes
+them after 30 days.
 
 ## Notes
 

--- a/tools/understand-anything/enrichments/enrich-database.json
+++ b/tools/understand-anything/enrichments/enrich-database.json
@@ -1,0 +1,87 @@
+{
+  "concepts": [
+    {
+      "id": "concept:central-schema-authority",
+      "name": "Central Schema Authority (Liquibase disabled)",
+      "summary": "Single source of truth for all platform database schemas. All backend services (TenantService, UserService, AgencyService, ConsultingTypeService) run with Liquibase DISABLED \u2014 schemas are version-controlled and applied from here, never auto-migrated at service startup.",
+      "tags": [
+        "database",
+        "core"
+      ],
+      "related": [
+        "README.md"
+      ]
+    },
+    {
+      "id": "concept:mariadb-schemas",
+      "name": "MariaDB Schemas (7 databases)",
+      "summary": "Per-service schema.sql files for agencyservice, consultingtypeservice, tenantservice, userservice, videoservice, uploadservice, and the shared caritas database.",
+      "tags": [
+        "database"
+      ],
+      "related": [
+        "schema.sql"
+      ]
+    },
+    {
+      "id": "concept:polyglot-stores",
+      "name": "Polyglot Stores (MongoDB, PostgreSQL, RabbitMQ, Redis)",
+      "summary": "Beyond MariaDB: MongoDB dumps for consulting types/application settings, PostgreSQL for Matrix/Synapse (status doc), plus RabbitMQ and Redis notes \u2014 each with its own README.",
+      "tags": [
+        "database"
+      ],
+      "related": [
+        "STATUS.md",
+        "prelude.json"
+      ]
+    },
+    {
+      "id": "concept:incident-2026-02",
+      "name": "Incident 2026-02 Remediation & Secret Management",
+      "summary": "docs/incident-2026-02/db-c03-remediation.md documents the remediation of the February 2026 MariaDB exposure incident; docs/secret-management.md defines how database credentials are stored and rotated.",
+      "tags": [
+        "security",
+        "operations"
+      ],
+      "related": [
+        "db-c03-remediation.md",
+        "secret-management.md"
+      ]
+    },
+    {
+      "id": "concept:mariadb-client-tooling",
+      "name": "In-Cluster MariaDB Client",
+      "summary": "k8s/mariadb-client provides a kustomize-deployed database client (deployment, service, ingress, configmap) for admin access to MariaDB inside the cluster.",
+      "tags": [
+        "operations"
+      ],
+      "related": [
+        "deployment.yaml",
+        "kustomization.yaml",
+        "configmap.yaml",
+        "ingress.yaml",
+        "service.yaml"
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "id": "flow:environment-init",
+      "name": "New Environment Initialization",
+      "summary": "scripts/database-initialize.yaml provisions the databases \u2192 per-service schema.sql files create the tables \u2192 scripts/system-users-job.yaml creates the system users; MongoDB collections restored from the tracked dumps.",
+      "related": [
+        "database-initialize.yaml",
+        "system-users-job.yaml",
+        "schema.sql"
+      ]
+    },
+    {
+      "id": "flow:sql-escaping-test",
+      "name": "SQL Escaping Test",
+      "summary": "tests/test-sql-escaping.sh validates schema files for escaping errors before they are applied to a live database.",
+      "related": [
+        "test-sql-escaping.sh"
+      ]
+    }
+  ]
+}

--- a/tools/understand-anything/enrichments/enrich-e2e.json
+++ b/tools/understand-anything/enrichments/enrich-e2e.json
@@ -1,0 +1,63 @@
+{
+  "concepts": [
+    {
+      "id": "concept:money-path-gate",
+      "name": "Money-Path E2E Gate",
+      "summary": "Dedicated Playwright repo industrializing the real-click E2E gate: ~10 money-path scenarios running nightly against the deployed Pre-Dev environment. Created because the Test Quality Audit 2026-07-04 found zero real automated E2E coverage.",
+      "tags": [
+        "testing",
+        "core"
+      ],
+      "related": [
+        "README.md",
+        "playwright.config.ts",
+        "package.json"
+      ]
+    },
+    {
+      "id": "concept:image-promotion-gating",
+      "name": "Image Promotion Gating (target state)",
+      "summary": "Target model: E2E green stamps the tested image digests as :predev-candidate \u2014 the gate blocks image promotion, not merges. Nightly workflow runs on cron and manual dispatch, publishing the Playwright report as an artifact.",
+      "tags": [
+        "ci",
+        "operations"
+      ],
+      "related": [
+        "README.md"
+      ]
+    },
+    {
+      "id": "concept:scenario-catalog",
+      "name": "Scenario Catalog",
+      "summary": "Current specs: money-path-counselling (core counselling journey), smoke-crash (app boots without crashing), t1-aside-confidentiality (tenant confidentiality aside). Projects: predev (via host-resolver rules against Pre-Dev) and local (compose skeleton).",
+      "tags": [
+        "testing"
+      ],
+      "related": [
+        "money-path-counselling.spec.ts",
+        "smoke-crash.spec.ts",
+        "t1-aside-confidentiality.spec.ts",
+        "docker-compose.e2e.yml"
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "id": "flow:nightly-run",
+      "name": "Nightly E2E Run",
+      "summary": "Cron (or manual dispatch) triggers nightly-e2e.yml \u2192 npm ci + playwright install \u2192 npx playwright test --project=predev against the deployed Pre-Dev stack \u2192 HTML report uploaded as workflow artifact; failures flag the candidate images as not promotable.",
+      "related": [
+        "playwright.config.ts"
+      ]
+    },
+    {
+      "id": "flow:local-run",
+      "name": "Local Run",
+      "summary": "Developer runs npx playwright test --project=local against the docker-compose.e2e.yml stack skeleton for scenario development without touching Pre-Dev.",
+      "related": [
+        "docker-compose.e2e.yml",
+        "playwright.config.ts"
+      ]
+    }
+  ]
+}

--- a/tools/understand-anything/enrichments/enrich-helm.json
+++ b/tools/understand-anything/enrichments/enrich-helm.json
@@ -1,0 +1,104 @@
+{
+  "concepts": [
+    {
+      "id": "concept:full-stack-chart",
+      "name": "Full-Stack Platform Chart",
+      "summary": "Umbrella Helm chart deploying the entire ORISO platform on Kubernetes: Keycloak, MariaDB, MongoDB, RabbitMQ, Redis, Matrix/Synapse, LiveKit, and all backend/frontend services as subcharts under charts/.",
+      "tags": [
+        "infrastructure",
+        "core"
+      ],
+      "related": [
+        "Chart.yaml",
+        "README.md"
+      ]
+    },
+    {
+      "id": "concept:config-secret-split",
+      "name": "Config/Secret Split (values.yaml + secrets.yaml)",
+      "summary": "Configuration is split across two gitignored files created from templates before deploying: values.yaml (domain, realm, Matrix server name) and secrets.yaml (all credentials). Only the *.default templates are tracked.",
+      "tags": [
+        "security",
+        "operations"
+      ],
+      "related": [
+        "README.md"
+      ]
+    },
+    {
+      "id": "concept:keycloak-subchart-theme",
+      "name": "Keycloak Subchart & Custom Theme",
+      "summary": "charts/keycloak carries the realm definition (realm.json), deployment templates, and the ORISO custom theme (login + OTP email templates, DE/EN messages, Nunito fonts) mounted via theme configmaps. restore-keycloak-settings.sh reapplies settings after redeploys.",
+      "tags": [
+        "identity",
+        "infrastructure"
+      ],
+      "related": [
+        "realm.json",
+        "restore-keycloak-settings.sh",
+        "keycloak-deployment.yaml",
+        "keycloak-theme-configmaps.yaml"
+      ]
+    },
+    {
+      "id": "concept:mariadb-subchart-schemas",
+      "name": "MariaDB Subchart & SQL Schemas",
+      "summary": "charts/mariadb ships per-service SQL schemas (agencyservice, consultingtypeservice, tenantservice, uploadservice, userservice) applied at provisioning time \u2014 the services themselves run with Liquibase disabled (see ORISO-Database).",
+      "tags": [
+        "database",
+        "infrastructure"
+      ],
+      "related": [
+        "agencyservice-schema.sql",
+        "consultingtypeservice-schema.sql",
+        "tenantservice-schema.sql",
+        "uploadservice-schema.sql",
+        "userservice-schema.sql"
+      ]
+    },
+    {
+      "id": "concept:deployment-authority",
+      "name": "Deployment Authority: dev only (NOT pre-dev)",
+      "summary": "OPERATIONAL WARNING: the pre-dev environment still runs the legacy ORISO-Kubernetes chart; ORISO-Helm has never deployed pre-dev. Running helm upgrade against pre-dev is destructive (first-deploy semantics). Deployment-authority cleanup is tracked in ORISO-Helm issue #149.",
+      "tags": [
+        "operations",
+        "warning"
+      ],
+      "related": [
+        "README.md",
+        "Chart.yaml"
+      ]
+    },
+    {
+      "id": "concept:chart-release-workflow",
+      "name": "Chart Release Workflow",
+      "summary": "GitHub Actions workflow packaging and releasing the Helm chart (release-helm-chart.yml).",
+      "tags": [
+        "ci"
+      ],
+      "related": [
+        "Chart.yaml",
+        "README.md"
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "id": "flow:deploy-platform",
+      "name": "Deploy Platform",
+      "summary": "Copy values.yaml.default \u2192 values.yaml and secrets.yaml.default \u2192 secrets.yaml, fill in domain/realm/credentials \u2192 helm install/upgrade the umbrella chart \u2192 subcharts provision Keycloak (realm + theme), databases (schemas), messaging, Matrix, LiveKit, and the ORISO services.",
+      "related": [
+        "README.md",
+        "Chart.yaml"
+      ]
+    },
+    {
+      "id": "flow:release-chart",
+      "name": "Release Chart",
+      "summary": "Chart changes merged \u2192 release-helm-chart.yml packages and publishes the chart release.",
+      "related": [
+        "Chart.yaml"
+      ]
+    }
+  ]
+}

--- a/tools/understand-anything/enrichments/enrich-infra.json
+++ b/tools/understand-anything/enrichments/enrich-infra.json
@@ -1,0 +1,39 @@
+{
+  "concepts": [
+    {
+      "id": "concept:cluster-provisioning",
+      "name": "Cluster Provisioning (dev on Hetzner)",
+      "summary": "Declarative k3s cluster on Hetzner Cloud via hetzner-k3s: clusters/dev-hetzner/cluster.yaml is the cluster config, apply.sh is the one-command provision+bootstrap entrypoint. Staging/prod run on Gridscale GSK and are managed separately.",
+      "tags": ["infrastructure", "core"],
+      "related": ["cluster.yaml", "apply.sh", "README.md"]
+    },
+    {
+      "id": "concept:bootstrap-components",
+      "name": "In-Cluster Bootstrap",
+      "summary": "bootstrap/ installs the in-cluster platform baseline idempotently: caritas namespace, block-storage StorageClass, cert-manager (Helm values under bootstrap/values/). Raw manifests live in bootstrap/manifests/.",
+      "tags": ["infrastructure"],
+      "related": ["bootstrap.sh", "caritas-namespace.yaml", "block-storage-sc.yaml", "cert-manager.yaml"]
+    },
+    {
+      "id": "concept:access-management",
+      "name": "Developer Access Management",
+      "summary": "add-developer.sh / remove-developer.sh grant and revoke cluster access; ACCESS-MANAGEMENT.md documents the admin and developer procedures.",
+      "tags": ["security", "operations"],
+      "related": ["add-developer.sh", "remove-developer.sh", "ACCESS-MANAGEMENT.md"]
+    }
+  ],
+  "flows": [
+    {
+      "id": "flow:provision-cluster",
+      "name": "Provision & Bootstrap Cluster",
+      "summary": "apply.sh → hetzner-k3s provisions the cluster from clusters/dev-hetzner/cluster.yaml → bootstrap/bootstrap.sh applies namespace + storage manifests and installs cert-manager → cluster ready for the ORISO-Helm platform chart.",
+      "related": ["apply.sh", "cluster.yaml", "bootstrap.sh"]
+    },
+    {
+      "id": "flow:developer-onboarding",
+      "name": "Developer On/Offboarding",
+      "summary": "Admin runs add-developer.sh to issue cluster access for a developer (procedure in ACCESS-MANAGEMENT.md); remove-developer.sh revokes it again.",
+      "related": ["add-developer.sh", "remove-developer.sh", "ACCESS-MANAGEMENT.md"]
+    }
+  ]
+}

--- a/tools/understand-anything/enrichments/enrich-userservice.json
+++ b/tools/understand-anything/enrichments/enrich-userservice.json
@@ -4,71 +4,128 @@
       "id": "concept:session-lifecycle",
       "name": "Consultation Session Lifecycle",
       "summary": "UserService owns the consultation lifecycle: registration of new users/askers, handling and creation of enquiries, creation of sessions with their chat group(s), and assignment of consultants to sessions.",
-      "tags": ["domain", "core"],
-      "related": ["UserController.java", "ConversationController.java", "SessionSupervisorController.java", "README.md"]
+      "tags": [
+        "domain",
+        "core"
+      ],
+      "related": [
+        "UserController.java",
+        "ConversationController.java",
+        "SessionSupervisorController.java",
+        "README.md"
+      ]
     },
     {
       "id": "concept:consultation-modes",
       "name": "Consultation Modes",
       "summary": "Four kinds of consultations are handled: single/direct 1:1 counseling, team counseling, group chat counseling, and anonymous counseling (no registration required).",
-      "tags": ["domain"],
-      "related": ["ConversationController.java", "README.md"]
+      "tags": [
+        "domain"
+      ],
+      "related": [
+        "ConversationController.java",
+        "README.md"
+      ]
     },
     {
       "id": "concept:matrix-messaging",
       "name": "Matrix-backed Messaging",
       "summary": "Real-time messaging runs on Matrix: MatrixMessageController and MatrixSyncController bridge sessions to Matrix rooms (the platform's migration away from the legacy Rocket.Chat group model).",
-      "tags": ["messaging", "matrix"],
-      "related": ["MatrixMessageController.java", "MatrixSyncController.java", "DraftMessageController.java"]
+      "tags": [
+        "messaging",
+        "matrix"
+      ],
+      "related": [
+        "MatrixMessageController.java",
+        "MatrixSyncController.java",
+        "DraftMessageController.java"
+      ]
     },
     {
       "id": "concept:user-administration",
       "name": "User & Consultant Administration",
       "summary": "Admin-facing account management: UserAdminController with ConsultantAdminFacade and AskerUserAdminFacade cover consultant/asker administration, agency assignment, and account state.",
-      "tags": ["admin"],
-      "related": ["UserAdminController.java", "ConsultantAdminFacade.java", "AskerUserAdminFacade.java", "AdminUserFacade.java"]
+      "tags": [
+        "admin"
+      ],
+      "related": [
+        "UserAdminController.java",
+        "ConsultantAdminFacade.java",
+        "AskerUserAdminFacade.java",
+        "AdminUserFacade.java"
+      ]
     },
     {
       "id": "concept:case-handover",
       "name": "Case Handover",
       "summary": "CaseHandoverController implements transferring cases between consultants/agencies, governed by reason policies.",
-      "tags": ["workflow"],
-      "related": ["CaseHandoverController.java"]
+      "tags": [
+        "workflow"
+      ],
+      "related": [
+        "CaseHandoverController.java"
+      ]
     },
     {
       "id": "concept:invite-links",
       "name": "Invite Links & Account Invitations",
       "summary": "AgencyInviteLinkController and AccountInviteController implement invitation-based onboarding (agency invite links, account invites).",
-      "tags": ["onboarding"],
-      "related": ["AgencyInviteLinkController.java", "AccountInviteController.java"]
+      "tags": [
+        "onboarding"
+      ],
+      "related": [
+        "AgencyInviteLinkController.java",
+        "AccountInviteController.java"
+      ]
     },
     {
       "id": "concept:availability-and-live-events",
       "name": "Live Availability & Event Notifications",
-      "summary": "ConsultantLiveAvailabilityController and TopicConsultantAvailabilityController expose consultant availability; LiveProxyController and EventNotificationController push live events and notifications to clients.",
-      "tags": ["realtime"],
-      "related": ["ConsultantLiveAvailabilityController.java", "TopicConsultantAvailabilityController.java", "LiveProxyController.java", "EventNotificationController.java"]
+      "summary": "ConsultantLiveAvailabilityController and TopicConsultantAvailabilityController expose consultant availability; DeprecatedLiveProxyController (deprecated proxy) and EventNotificationController push live events and notifications to clients.",
+      "tags": [
+        "realtime"
+      ],
+      "related": [
+        "ConsultantLiveAvailabilityController.java",
+        "TopicConsultantAvailabilityController.java",
+        "DeprecatedLiveProxyController.java",
+        "EventNotificationController.java"
+      ]
     },
     {
       "id": "concept:statistics-and-audit",
       "name": "Statistics & Audit Logs",
       "summary": "AdminStatisticsController and UserStatisticsController expose usage statistics; InactiveAccountAuditLogsController and SupervisorLogsController provide audit trails.",
-      "tags": ["reporting"],
-      "related": ["AdminStatisticsController.java", "UserStatisticsController.java", "InactiveAccountAuditLogsController.java", "SupervisorLogsController.java"]
+      "tags": [
+        "reporting"
+      ],
+      "related": [
+        "AdminStatisticsController.java",
+        "UserStatisticsController.java",
+        "InactiveAccountAuditLogsController.java",
+        "SupervisorLogsController.java"
+      ]
     }
   ],
   "flows": [
     {
       "id": "flow:enquiry-to-session",
-      "name": "Enquiry → Session → Consultant Assignment",
-      "summary": "An asker registers → creates an enquiry → a session with its chat group is created → a consultant (or team) is assigned and the conversation begins.",
-      "related": ["UserController.java", "ConversationController.java", "ConsultantAdminFacade.java"]
+      "name": "Enquiry \u2192 Session \u2192 Consultant Assignment",
+      "summary": "An asker registers \u2192 creates an enquiry \u2192 a session with its chat group is created \u2192 a consultant (or team) is assigned and the conversation begins.",
+      "related": [
+        "UserController.java",
+        "ConversationController.java",
+        "ConsultantAdminFacade.java"
+      ]
     },
     {
       "id": "flow:matrix-message-roundtrip",
       "name": "Matrix Message Roundtrip",
-      "summary": "Client sends via MatrixMessageController → message lands in the session's Matrix room → MatrixSyncController keeps session state and read models in sync.",
-      "related": ["MatrixMessageController.java", "MatrixSyncController.java"]
+      "summary": "Client sends via MatrixMessageController \u2192 message lands in the session's Matrix room \u2192 MatrixSyncController keeps session state and read models in sync.",
+      "related": [
+        "MatrixMessageController.java",
+        "MatrixSyncController.java"
+      ]
     }
   ]
 }

--- a/tools/understand-anything/ua-build-supergraph.mjs
+++ b/tools/understand-anything/ua-build-supergraph.mjs
@@ -20,7 +20,7 @@ const INSTALL = process.argv.includes("--install");
 const REPOS = [
   "ORISO-Frontend", "ORISO-Admin", "ORISO-UserService", "ORISO-AgencyService",
   "ORISO-ConsultingTypeService", "ORISO-TenantService", "ORISO-Database",
-  "ORISO-Keycloak", "ORISO-Kubernetes",
+  "ORISO-Keycloak", "ORISO-Kubernetes", "ORISO-Helm", "ORISO-E2E", "ORISO-Infra",
 ];
 
 // keyword -> owning repo, for deterministic cross-repo dependency inference
@@ -31,6 +31,9 @@ const SERVICE_KEYWORDS = [
   [/user.?service|user.?admin.?service/i, "ORISO-UserService"],
   [/keycloak/i, "ORISO-Keycloak"],
   [/mariadb|mongodb/i, "ORISO-Database"],
+  [/\bhelm\b/i, "ORISO-Helm"],
+  [/playwright/i, "ORISO-E2E"],
+  [/hetzner|\bk3s\b/i, "ORISO-Infra"],
 ];
 
 const nodes = [], edges = [], layers = [];
@@ -160,12 +163,20 @@ console.log(JSON.stringify({
 if (INSTALL) {
   const live = `${BASE}/ORISO-Docs/.understand-anything`;
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  copyFileSync(`${live}/knowledge-graph.json`, `${live}/knowledge-graph.json.bak-prerebuild-${ts}`);
+  copyFileSync(`${live}/knowledge-graph.json`, `${live}/knowledge-graph.json.bak-${ts}`);
   copyFileSync(`${OUT}/knowledge-graph.json`, `${live}/knowledge-graph.json`);
   copyFileSync(`${OUT}/knowledge-graph.json`, `${live}/oriso-super-graph.json`);
   writeFileSync(`${live}/oriso-super-graph-summary.md`,
     `# ORISO Super-Graph\n\nRebuilt ${new Date().toISOString()} by ua-build-supergraph.mjs (deterministic).\n\n` +
     mergeSources.map(s => `- ${s.repo}: ${s.nodes} nodes / ${s.edges} edges @ ${(s.gitCommitHash ?? "?").slice(0, 8)}`).join("\n") +
     `\n\nCross-repo dependency edges: ${crossEdges} (keyword inference, evidence-count >= 2).\n`);
+  writeFileSync(`${live}/meta.json`, JSON.stringify({
+    lastAnalyzedAt: new Date().toISOString(),
+    gitCommitHash: "supergraph",
+    version: "1.0.0",
+    analyzedFiles: graph.nodes.length,
+    generator: "ua-build-supergraph.mjs (deterministic cross-repo merge)",
+    repos: Object.fromEntries(mergeSources.map(s => [s.repo, (s.gitCommitHash ?? "?").slice(0, 9)])),
+  }, null, 2) + "\n");
   console.log("INSTALLED into ORISO-Docs/.understand-anything/");
 }

--- a/tools/understand-anything/ua-build-supergraph.mjs
+++ b/tools/understand-anything/ua-build-supergraph.mjs
@@ -163,7 +163,8 @@ console.log(JSON.stringify({
 if (INSTALL) {
   const live = `${BASE}/ORISO-Docs/.understand-anything`;
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  copyFileSync(`${live}/knowledge-graph.json`, `${live}/knowledge-graph.json.bak-${ts}`);
+  if (existsSync(`${live}/knowledge-graph.json`))
+    copyFileSync(`${live}/knowledge-graph.json`, `${live}/knowledge-graph.json.bak-${ts}`);
   copyFileSync(`${OUT}/knowledge-graph.json`, `${live}/knowledge-graph.json`);
   copyFileSync(`${OUT}/knowledge-graph.json`, `${live}/oriso-super-graph.json`);
   writeFileSync(`${live}/oriso-super-graph-summary.md`,

--- a/tools/understand-anything/ua-nightly-full.sh
+++ b/tools/understand-anything/ua-nightly-full.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Nightly FULL rebuild of all Understand-Anything graphs (replaces the
+# overlay/baseline approach of refresh-understand-ultralite-local.sh).
+# Deterministic pipeline, ~3s/repo: advance clone -> generate -> enrich ->
+# install -> supergraph. Dashboards read graphs from disk per request, so no
+# container restarts are needed.
+set -uo pipefail
+BASE=/opt/oriso-understand
+RB=$BASE/_rebuild
+LOCK=/tmp/ua-nightly-full.lock
+exec 9>"$LOCK"; flock -n 9 || { echo "$(date -Is) another run active, exiting"; exit 0; }
+STAMP=$(date +%Y-%m-%dT%H-%M-%S)
+echo "=== ua-nightly-full $STAMP ==="
+
+# repo:enrichment (enrichment empty = none)
+REPOS=(
+  "ORISO-Admin:enrich-admin.json"
+  "ORISO-AgencyService:enrich-agencyservice.json"
+  "ORISO-ConsultingTypeService:enrich-cts.json"
+  "ORISO-Database:enrich-database.json"
+  "ORISO-Frontend:enrich-frontend.json"
+  "ORISO-Keycloak:enrich-keycloak.json"
+  "ORISO-Kubernetes:enrich-kubernetes.json"
+  "ORISO-TenantService:enrich-tenantservice.json"
+  "ORISO-UserService:enrich-userservice.json"
+  "ORISO-Helm:enrich-helm.json"
+  "ORISO-E2E:enrich-e2e.json"
+  "ORISO-Infra:enrich-infra.json"
+)
+
+FAIL=0
+# advance the ORISO-Docs clone too (hosts the supergraph + docs file views)
+for spec in "${REPOS[@]}" "ORISO-Docs:"; do
+  R=${spec%%:*}
+  cd "$BASE/$R" || { echo "MISSING $R"; FAIL=1; continue; }
+  B=$(git rev-parse --abbrev-ref HEAD)
+  git fetch -q origin "$B" 2>/dev/null && git reset -q --hard "origin/$B" \
+    || echo "WARN: fetch/advance failed for $R (keeping local tip)"
+done
+
+for spec in "${REPOS[@]}"; do
+  R=${spec%%:*}; E=${spec#*:}
+  cd "$RB" || exit 1
+  if ! node ua-generate.mjs "$BASE/$R" "$R" "./$R" > "/tmp/ua-gen-$R.log" 2>&1; then
+    echo "GEN FAIL $R:"; tail -3 "/tmp/ua-gen-$R.log"; FAIL=1; continue
+  fi
+  if [ -n "$E" ] && [ -f "$RB/$E" ]; then
+    if ! node ua-enrich-merge.mjs "./$R" "$E" > "/tmp/ua-enr-$R.log" 2>&1; then
+      echo "ENRICH FAIL $R:"; tail -3 "/tmp/ua-enr-$R.log"; FAIL=1; continue
+    fi
+  fi
+  LIVE=$BASE/$R/.understand-anything
+  mkdir -p "$LIVE"
+  [ -f "$LIVE/knowledge-graph.json" ] && cp "$LIVE/knowledge-graph.json" "$LIVE/knowledge-graph.json.bak-$STAMP"
+  cp "./$R/knowledge-graph.json" "./$R/meta.json" "./$R/fingerprints.json" "$LIVE/" || { echo "INSTALL FAIL $R"; FAIL=1; continue; }
+  echo "OK $R $(git -C "$BASE/$R" rev-parse --short HEAD)"
+done
+
+cd "$RB" && node ua-build-supergraph.mjs --install > /tmp/ua-supergraph.log 2>&1 \
+  && echo "OK supergraph" || { echo "SUPERGRAPH FAIL:"; tail -5 /tmp/ua-supergraph.log; FAIL=1; }
+
+echo "=== done $(date -Is) fail=$FAIL ==="
+exit $FAIL


### PR DESCRIPTION
## What

Syncs the Understand-Anything pipeline changes deployed to `oriso-understand-dev-1` on 2026-08-05 (EPIC #61 follow-up):

- **Board now tracks `pre-dev`** for the 6 service repos (Frontend, Admin, UserService, AgencyService, ConsultingTypeService, TenantService) — previously `dev`, which lagged the actual integration branch.
- **Three new dashboards**: ORISO-Helm, ORISO-E2E, ORISO-Infra (ports 5183–5185, wired into nginx + landing page). Super-graph now spans 12 repos (22.2k nodes / 48.2k edges).
- **`ua-nightly-full.sh`**: the 02:00 cron now does a full deterministic rebuild of every graph + the super-graph (~90 s) instead of overlay-patching a frozen base — the base can no longer go stale.
- **`ua-build-supergraph.mjs`**: new repos + keyword rules, writes `meta.json` on install, install backups moved to the 7-day retention class.
- **Enrichments**: new for helm/e2e/infra/database; userservice fixed for the `DeprecatedLiveProxyController` rename. All 12 repos merge with 0 unresolved refs.
- **README**: repo/branch matrix, nightly operation, bak retention (daily 7 d, prerebuild 30 d).

## Validation

- Full pipeline run on the server: 12/12 repos OK + super-graph OK, `fail=0`, 0 unresolved enrichment refs.
- All 13 dashboards verified through nginx: app 200, `meta.json` 200 with token, 403 with wrong token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)