### PR TITLE
docs: reconcile handover.mdx with the code and document the account recovery gap

### DIFF
--- a/product/edge-cases.mdx
+++ b/product/edge-cases.mdx
@@ -347,18 +347,20 @@ the anonymity model rather than a fault — but it was written down nowhere unti
 | **Risk if mishandled** | Someone in distress is silently locked out of a counseling conversation they had already started, with no message telling them why |
 | **Test** | Register anonymously without an e-mail, sign out, attempt to sign back in with a wrong password: there is no reset link anywhere on the page |
 
-**The three paths that silently no-op**, each for a reason that must be preserved:
+**The three paths that do not restore account access.** They fail in three different ways, and the
+difference matters — only the first is silent, and only the first is silent *on purpose*:
 
-1. **Password reset.** `PasswordResetService` returns without sending for accounts whose address
-   is blank or ends with the synthetic dummy suffix — which is exactly what an anonymous seeker
-   gets (`UserHelper`, `identity.email-dummy-suffix`). The person sees "E-Mail wurde versendet"
-   and nothing ever arrives. **This is deliberate account-enumeration protection**: constant-time
-   async dispatch, an identical response even on queue saturation, no PII in logs. Do not "fix" it
-   into an informative response.
-2. **Magic Link.** Requires a real address — `validateMagicLinkTogglePrerequisites` rejects
-   enabling it otherwise. It is a convenience login, **not** a recovery path.
-3. **The Matrix recovery key.** Restores **message history**, not account access. Calling it
-   account recovery is a category error.
+1. **Password reset — silently no-ops.** `PasswordResetService` returns without sending for
+   accounts whose address is blank or ends with the synthetic dummy suffix, which is exactly what
+   an anonymous seeker gets (`UserHelper`, `identity.email-dummy-suffix`). The person sees
+   "E-Mail wurde versendet" and nothing ever arrives. **This silence is deliberate
+   account-enumeration protection**: constant-time async dispatch, an identical response even on
+   queue saturation, no PII in logs. Do not "fix" it into an informative response.
+2. **Magic Link — rejects outright.** `validateMagicLinkTogglePrerequisites` refuses to enable it
+   without a real address. It does not fail quietly; it cannot be turned on at all. And it is a
+   convenience login, **not** a recovery path even when it works.
+3. **The Matrix recovery key — succeeds at something else.** It restores **message history**, not
+   account access. Treating it as account recovery is a category error, not a malfunction.
 
 **The compensation, and why it matters more for some Träger than others.** For a Träger that
 switches the e-mail invitation off — U25 does — credential saving is the **only** remaining safety

--- a/product/edge-cases.mdx
+++ b/product/edge-cases.mdx
@@ -329,6 +329,49 @@ Even though the AI path is not yet built, the failure modes to design for:
 | External escalation timed out (24 h) | Cancelled silently; nothing leaves the system; counselor informed |
 | Help Request to a counselor on holiday | Falls back to next-up Supervisor in the agency |
 
+## 9.14 Account Recovery Edge Cases
+
+### 9.14.1 The advice seeker forgot their password and left no e-mail address
+
+<Warning>
+**There is no recovery. The account is lost, permanently.** This is a structural consequence of
+the anonymity model rather than a fault — but it was written down nowhere until 2026-08-08
+(OpenResilienceInitiative/ORISO-UserService#928), which is what made it indefensible.
+</Warning>
+
+| | |
+|---|---|
+| **Trigger** | Anonymous registration with no e-mail address; the person later cannot sign in |
+| **Expected** | No path back into the account exists. The `userName` (Anmeldename) is the only handle, and it is immutable; the generated 16-character password is never shown again after registration |
+| **What the person actually sees** | Nothing that explains it. The deployed login page for realm `online-beratung` renders **no** "forgot password" affordance at all (`resetPasswordAllowed: false`), and a cold `GET /realms/online-beratung/login-actions/reset-credentials` returns 400 with an error page |
+| **Risk if mishandled** | Someone in distress is silently locked out of a counselling conversation they had already started, with no message telling them why |
+| **Test** | Register anonymously without an e-mail, sign out, attempt to sign back in with a wrong password: there is no reset link anywhere on the page |
+
+**The three paths that silently no-op**, each for a reason that must be preserved:
+
+1. **Password reset.** `PasswordResetService` returns without sending for accounts whose address
+   is blank or ends with the synthetic dummy suffix — which is exactly what an anonymous seeker
+   gets (`UserHelper`, `identity.email-dummy-suffix`). The person sees "E-Mail wurde versendet"
+   and nothing ever arrives. **This is deliberate account-enumeration protection**: constant-time
+   async dispatch, an identical response even on queue saturation, no PII in logs. Do not "fix" it
+   into an informative response.
+2. **Magic Link.** Requires a real address — `validateMagicLinkTogglePrerequisites` rejects
+   enabling it otherwise. It is a convenience login, **not** a recovery path.
+3. **The Matrix recovery key.** Restores **message history**, not account access. Calling it
+   account recovery is a category error.
+
+**The compensation, and why it matters more for some Träger than others.** For a Träger that
+switches the e-mail invitation off — U25 does — credential saving is the **only** remaining safety
+net, which makes it more important there, not less. That is the `saveCredentials` Baustein of the
+Erstantwort (ADR-018, OpenResilienceInitiative/ORISO-Frontend#825): shown after the enquiry is
+dispatched, with a shared-device warning, and **never as a file download**, because a
+`zugangsdaten.txt` in the download folder is a lasting trace on a device somebody else may use.
+
+**Current position:** *no recovery; credential saving is the mitigation.* A recovery code issued at
+registration — following the shipped Matrix recovery-key flow, with one-time display and an "I have
+stored it" confirmation — is the named alternative and is **not rejected on the merits**, only not
+yet decided. The decision belongs in its own record; see ORISO-UserService#928.
+
 ## 9.8 Compact "What Happens If…" Cheat Sheet
 
 | If… | Then… |
@@ -340,6 +383,7 @@ Even though the AI path is not yet built, the failure modes to design for:
 | Live-chat link disabled mid-session | Active continues; new visits blocked |
 | Tenant disabled | Read-only; active sessions finish |
 | Magic link reused | HTTP 410 |
+| Anonymous account, no e-mail, password forgotten | **No recovery — the account is lost.** See §9.14.1 |
 | Browser cookies off | Friendly explainer |
 | Queue counter inconsistent | Redis Pub/Sub re-derives from DB on next event |
 | Client deletes self mid-video-call (initiator) | Call survives among counselors; initiator role transfers; client wiped |

--- a/product/edge-cases.mdx
+++ b/product/edge-cases.mdx
@@ -344,7 +344,7 @@ the anonymity model rather than a fault — but it was written down nowhere unti
 | **Trigger** | Anonymous registration with no e-mail address; the person later cannot sign in |
 | **Expected** | No path back into the account exists. The `userName` (Anmeldename) is the only handle, and it is immutable; the generated 16-character password is never shown again after registration |
 | **What the person actually sees** | Nothing that explains it. The deployed login page for realm `online-beratung` renders **no** "forgot password" affordance at all (`resetPasswordAllowed: false`), and a cold `GET /realms/online-beratung/login-actions/reset-credentials` returns 400 with an error page |
-| **Risk if mishandled** | Someone in distress is silently locked out of a counselling conversation they had already started, with no message telling them why |
+| **Risk if mishandled** | Someone in distress is silently locked out of a counseling conversation they had already started, with no message telling them why |
 | **Test** | Register anonymously without an e-mail, sign out, attempt to sign back in with a wrong password: there is no reset link anywhere on the page |
 
 **The three paths that silently no-op**, each for a reason that must be preserved:

--- a/product/features/handover.mdx
+++ b/product/features/handover.mdx
@@ -152,15 +152,23 @@ surface where a client acts on a handover.
 ### The dead predecessor
 
 The reassignment path — `REASSIGN_CONSULTANT`, `apiPatchMessage`, `apiSendAliasMessage` — is the
-**legacy predecessor** of case handover and is dead. No Matrix code path produces the `alias`
-object those renderers key off, UserService on `pre-dev` has no `PATCH /messages/{id}` handler,
-and no `messageservice` deployment exists while `MESSAGE_SERVICE_API_URL` still points at one.
-Both frontend call sites swallow their errors silently, which is why it stayed invisible for so
-long. Do not extend it; do not cite it as a pattern.
+**legacy predecessor** of case handover and is dead. Do not extend it; do not cite it as a pattern.
+
+Three separate claims sit behind that, at three different levels of certainty. Keeping them apart
+matters, because an earlier draft collapsed them and got the first one wrong:
+
+| Claim | Status | Evidence |
+|---|---|---|
+| **The renderers cannot fire.** No Matrix code path produces the `alias` object `ReassignMessage` and `FurtherSteps` key off. | **Established** | Read from `origin/pre-dev`. This alone makes the path dead in the client. |
+| **The endpoint is not implemented.** UserService on `origin/pre-dev` has no `PATCH /messages/{id}` handler, and no `messageservice` deployment exists although `MESSAGE_SERVICE_API_URL` still points at one. | **Established from code and the Pre-Dev manifests** | Source-level, not a runtime probe. |
+| **What an authenticated `PATCH /service/messages/{id}` actually does.** | **Untested — do not assume either way** | A 401 is raised by the auth layer before controller mapping, so it is equally consistent with "a handler exists" and "no handler, rejected earlier". |
+
+Both frontend call sites swallow their errors silently, which is why this stayed invisible for so
+long.
 
 <Note>
-One earlier claim about this path was **wrong and is retracted**: that `/service/messages/*` is
-unrouted and falls through to the SPA. Measured on Pre-Dev 2026-07-30, `GET /service/messages/`
+**The retraction.** An earlier claim about the *first* row above was wrong: that
+`/service/messages/*` is unrouted and falls through to the SPA. Measured on Pre-Dev 2026-07-30, `GET /service/messages/`
 answers **401 with a Bearer challenge** exactly like the routed control `/service/users/data`,
 while an unknown path answers 404 — so the path *is* routed. The wrong claim came from reading the
 ORISO-Helm chart, which **Pre-Dev does not run** (it still runs the archived ORISO-Kubernetes

--- a/product/features/handover.mdx
+++ b/product/features/handover.mdx
@@ -50,18 +50,29 @@ Confirmed in Figma:
 Each tenant can override the default consent rules in the **Berechtigungen** matrix (see [Roles & Permissions §3.7](/product/roles-permissions#3-7-per-chat-type-permissions-matrix)).
 </Note>
 
-## 4.7.3 Consent Matrix
+## 4.7.3 Consent Model
 
-| Reason | Client consent | Counselor B consent | Supervisor approval | Reason text shown to client |
-|---|:-:|:-:|:-:|---|
-| Holiday | ✅ | ✅ | ❌ | *"Deine vorherige Beraterin ist im Urlaub …"* |
-| Sickness | informed only | ✅ | ❌ | *"Deine vorherige Beraterin ist leider krank …"* |
-| Emergency | informed only (post-fact OK) | ✅ (best effort) | optional | *"Aus dringenden Gründen wurde dein Fall übertragen …"* |
-| Law Violation | restricted notification | ✅ | ✅ + LEO repr. | locked text from legal team |
-| Colleague fired | informed only | ✅ | ✅ | *"Aus organisatorischen Gründen wurde dein Fall übertragen …"* |
-| Custom | ✅ | ✅ | ❌ | counselor-typed reason text |
+<Warning>
+**Superseded 2026-07-06, corrected 2026-08-08.** The per-reason blocking consent matrix that
+used to stand here was never built, and the model it described was reversed by the decision
+recorded in `ORISO-UserService/CONTEXT.md` and ADR-008: handover is **disclosed by default and
+client-switchable**, and **no reason requires an upfront blocking consent gate**. Three
+descriptions of this existed and all three differed from each other and from the code
+(ORISO-Docs#73).
+</Warning>
 
-The system enforces these rules **server-side** before the room is rotated.
+**What the code does today.** Handover is disclosed to the client, not gated on their approval.
+The client-side opt-out switch that governs team access is tracked separately in
+OpenResilienceInitiative/ORISO-UserService#313 and is deliberately **out of scope** for the
+Erstantwort catalogue (ADR-018 §4), because it carries genuinely new state rather than reading
+state that already exists.
+
+| Reason | Blocking client consent | Counselor B consent | Supervisor approval |
+|---|:-:|:-:|:-:|
+| Holiday · Sickness · Emergency · Law violation · Colleague left · Custom | ❌ — disclosed, not gated | ✅ | only for `law_violation` |
+
+The reason taxonomy itself is platform-global: `case_handover_reason_policy` carries no
+`tenant_id`, so per-tenant overrides are **not representable** (ADR-002). See §4.7.5.
 
 ## 4.7.4 Detailed Sequence
 
@@ -108,6 +119,13 @@ sequenceDiagram
 - **Megolm keys**: Counselor B receives forward history depending on the room's `m.room.history_visibility`. Default for ORISO is `shared` (members see history from when they were invited). For sensitive sessions the tenant can switch to `joined` (no back-history) so a new counselor starts clean.
 - **Client identity** is unchanged — same pseudonym, same cookie. The client doesn't get re-paired; only the counselor seat changes.
 
+<Note>
+**Corrected 2026-08-08 (ORISO-Docs#73).** An earlier revision of this section claimed per-tenant
+overrides of the consent rules. There are none, and there cannot be: `case_handover_reason_policy`
+is platform-global with no `tenant_id` column (ADR-002), and the Admin card's own header comment
+says the same. Treat the taxonomy as a platform decision, not as tenant configuration.
+</Note>
+
 ## 4.7.6 Constraints
 
 - **Cross-agency handover is forbidden** — replacements must be from the same agency. If the agency has no other counselor, a tenant-level escalation path is required (planned, see [Figma analysis §4.6](/product/figma-analysis-2026-05#4-6-handover-reasons-consent)).
@@ -118,15 +136,37 @@ sequenceDiagram
 
 ## 4.7.7 Client Experience
 
-The client always sees an in-chat **System Message** of type `Handover` with a templated body:
+<Warning>
+**Corrected 2026-08-08 (ORISO-Docs#73).** This section used to describe **Akzeptieren /
+Ablehnen / Mehr erfahren** buttons in the chat. **They do not exist and never did.** A reader
+following the old text would have built the wrong thing.
+</Warning>
 
-> Deine vorherige Beraterin ist leider krank. Deshalb wurde dein Fall an **{Beraterin}** übergeben von der **{Beratungsstelle}**.
+**What the client actually sees.** One in-chat card, `CaseHandoverSystemMessageCard`, which is
+explicitly *informational* — its own copy is "Du musst nichts weiter tun". There are no buttons on
+it and there is no "Mehr erfahren" modal.
 
-Buttons (depending on consent rule):
+**Where the decision lives.** In the **Notifications Center**, not in the chat. That is the only
+surface where a client acts on a handover.
 
-- **Akzeptieren** — accept the new counselor, conversation continues.
-- **Ablehnen** — refuse; case is closed; client wiped.
-- **Mehr erfahren** — opens a modal with the full reason text and contact for the agency.
+### The dead predecessor
+
+The reassignment path — `REASSIGN_CONSULTANT`, `apiPatchMessage`, `apiSendAliasMessage` — is the
+**legacy predecessor** of case handover and is dead. No Matrix code path produces the `alias`
+object those renderers key off, UserService on `pre-dev` has no `PATCH /messages/{id}` handler,
+and no `messageservice` deployment exists while `MESSAGE_SERVICE_API_URL` still points at one.
+Both frontend call sites swallow their errors silently, which is why it stayed invisible for so
+long. Do not extend it; do not cite it as a pattern.
+
+<Note>
+One earlier claim about this path was **wrong and is retracted**: that `/service/messages/*` is
+unrouted and falls through to the SPA. Measured on Pre-Dev 2026-07-30, `GET /service/messages/`
+answers **401 with a Bearer challenge** exactly like the routed control `/service/users/data`,
+while an unknown path answers 404 — so the path *is* routed. The wrong claim came from reading the
+ORISO-Helm chart, which **Pre-Dev does not run** (it still runs the archived ORISO-Kubernetes
+release, ORISO-Helm#110). Whether an *authenticated* `PATCH` reaches a handler remains untested;
+do not assume it either way.
+</Note>
 
 ## 4.7.8 Audit & Compliance
 


### PR DESCRIPTION
Closes the documentation half of **EPIC OpenResilienceInitiative/ORISO-Frontend#824 — Erstantwort**: ORISO-Docs#73 and part 1 of OpenResilienceInitiative/ORISO-UserService#928.

Branched from `main`; **not stacked on anything**.

## `handover.mdx` — three descriptions that did not match the code

A reader following this file would have built the wrong thing, so each correction is marked in place rather than quietly rewritten:

- **§4.7.3** carried a blocking per-reason consent matrix that predates the 2026-07-06 decision (`ORISO-UserService/CONTEXT.md`, ADR-008). Handover is **disclosed by default and client-switchable**; no reason requires an upfront blocking gate. Three descriptions of this existed and all three differed from each other and from the code.
- **§4.7.7** documented **Akzeptieren / Ablehnen / Mehr erfahren** buttons in the chat. **They do not exist.** The only in-chat surface is `CaseHandoverSystemMessageCard`, whose own copy is "Du musst nichts weiter tun"; the decision lives in the Notifications Center, and there is no "Mehr erfahren" modal.
- **§4.7.5** claimed per-tenant overrides of the consent rules. They are **not representable** — `case_handover_reason_policy` is platform-global with no `tenant_id` (ADR-002).

The dead `REASSIGN_CONSULTANT` path is now documented as the legacy predecessor it is, with the routing reason — **including a retraction.** An earlier claim that `/service/messages/*` is unrouted and falls through to the SPA was **wrong**; measured on Pre-Dev it answers 401 with a Bearer challenge like any routed path. It came from reading the ORISO-Helm chart, which **Pre-Dev does not run**.

## `edge-cases.mdx` — the recovery gap, §9.14.1

The file had rows for cookies-off, magic-link reuse and a disabled tenant, and **no row for "the advice seeker forgot their password"** — the case where the account is lost forever.

It now records what the person actually sees (no reset affordance at all on the deployed login page), which three paths silently no-op, and **why the password-reset silence must be preserved**: it is deliberate account-enumeration protection, not a bug to be "fixed" into an informative response. Current position recorded as *no recovery; credential saving is the mitigation*, with the recovery code named as **not yet decided** rather than rejected.

## Workspace `0 - Docs` (not in this diff — it is not a git repo)

- **The ADR-014 collision is resolved.** Two accepted ADRs both carried 014. The later one (media scanning, 2026-07-18) became **ADR-019**; shared-legal-text-objects (2026-07-16) keeps 014. Both files carry a note, and every inbound reference was updated or disambiguated.
- **`issue-task-workflow.md` corrected against the live API**, and it was staler than #73 knew:
  - `Epic` **is** an org issue type now (`IT_kwDODkeBP84CFFbE`) — and the third type is named **`Feature`**, not `Feature Request`, so a script passing the old string fails.
  - The `Priority` field id was stale: live is `PVTSSF_lADODkeBP84BHH8pzhZEwRA`.
  - **New finding:** there is **no `Quarter` field on the board at all**. The recorded id resolves to nothing. The board's single-selects are exactly `Status`, `Priority`, `Size`, `Effort`; scheduling lives in `Start date` and `Platform release`. Anything still setting "Quarter" is writing to a field that is not there.

## Not in here

The **repo copies** of the two ADR-014 files exist only on the unmerged branch `docs/import-platform-adrs`. Renaming them there would mean stacking this PR on an open one, which is how a finished change ends up frozen behind a stalled review — so that rename belongs to that PR. Flagged on #73.

## Reviewer test plan

- [ ] `handover.mdx` §4.7.7 no longer promises buttons; the callout explains what replaced them
- [ ] §4.7.3 reads as disclosed-not-gated and points at ADR-008
- [ ] §4.7.5 states plainly that tenant overrides are not representable
- [ ] The `REASSIGN_CONSULTANT` section says "legacy, dead, do not extend"
- [ ] `edge-cases.mdx` §9.14.1 is findable from the cheat sheet row
- [ ] §9.14.1 does **not** read as a call to make the reset endpoint informative
- [ ] Mintlify build renders both files without broken anchors
- [ ] Mobile: both pages readable on a phone-sized viewport

Refs OpenResilienceInitiative/ORISO-Docs#73, OpenResilienceInitiative/ORISO-UserService#928, OpenResilienceInitiative/ORISO-Frontend#824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
